### PR TITLE
Avoid making request for each member and refactor

### DIFF
--- a/tests/test_ballot.py
+++ b/tests/test_ballot.py
@@ -25,18 +25,13 @@ def test_member_name():
 
 @patch('time.sleep')
 def test_filter_spam_members(_):
-    names = [
-        None,
-        'Word',
-        'A BC',
-        'Uncle Bob'
+    members = [
+        {"id": 1, "name": None},
+        {"id": 2, "name": 'Word'},
+        {"id": 3, "name": 'A BC'},
+        {"id": 4, "name": 'Uncle Bob'}
     ]
-    mocked_client = MagicMock(
-        get_member_name=MagicMock(
-            side_effect=names
-        )
-    )
-    actual = ballot.filter_spam_members([1, 2, 3, 4], mocked_client)
+    actual = ballot.filter_spam_members(members)
 
     eq_([4], actual)
 

--- a/tests/test_meetup.py
+++ b/tests/test_meetup.py
@@ -114,7 +114,7 @@ class TestMeetup(TestCase):
         )
         self.assertEqual([1], response)
 
-    def test_get_member_ids_from_rsvps(self):
+    def test_get_members_from_rsvps(self):
         rsvps = [
             get_rsvp(id=1, role=False, host=False),
             get_rsvp(id=2, role=True, host=False),
@@ -122,12 +122,15 @@ class TestMeetup(TestCase):
             get_rsvp(id=4, role=False, host=False),
             get_rsvp(id=5, role=True, host=True),
         ]
-        member_ids = self.client.get_member_ids_from_rsvps(rsvps=rsvps)
-        self.assertListEqual([1, 4], member_ids)
+        member_ids = self.client.get_members_from_rsvps(rsvps=rsvps)
+        self.assertListEqual([
+            {'event_context': {'host': False}, 'id': 1},
+            {'event_context': {'host': False}, 'id': 4}
+        ], member_ids)
 
 
 def get_rsvp(id, role=False, host=False):
-    rsvp = {"member": {"id": id, "event_context": {"host": host}}}
+    rsvp = {"member": {"id": id, "event_context": {"host": host}}, "response": "yes"}
     if role:
         rsvp["member"]["role"] = "coorganizer"
     return rsvp


### PR DESCRIPTION
It seems we were making request for each rsvp'd member to get their names, even though we already had it from previous requests. This PR:

- Avoid making those 300 odd requests (MAX_RSVPS) and refactors 
- Only RSVP the members who have responded yes.